### PR TITLE
Allow for configuration of as_json includes

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,30 @@ DELETE /
 
 This returns 204 No Content when successful.
 
-### Attributes
+### Overriding Factory Attributes
 
-You may specify attributes with your GET and POST requests using JSON as follows:
+You may override factory properties on your GET and POST requests using JSON as follows:
 
 ```
 { "post": { "title": "Dolor Sit Amet" } }
 ```
+
+### Specifying Returned JSON Attributes
+
+Specifying JSON attributes to return is the same as the ActiveModel::Serializer's as_json() include option. In the below examples, comments is a has_many association of our model.
+
+
+To include associations POST the JSON as follows:
+
+```
+{ "include": "comments" }
+```
+
+To specify which attributes to include on associations, POST the JSON as follows:
+{ "include": { "comments": { "only": "text" } } }
+
+In this case, text is an attribute on our comments model.
+
 
 ### Headers
 
@@ -59,6 +76,7 @@ You must include the following headers with your requests:
 
 ```
 Accept: application/json; charset=utf-8
+Content-Type: application/json    
 Factory: hangar
 ```
 

--- a/app/controllers/hangar/resources_controller.rb
+++ b/app/controllers/hangar/resources_controller.rb
@@ -4,7 +4,7 @@ module Hangar
 
     def create
       created = FactoryGirl.create resource, resource_attributes
-      render json: created
+      render json: created.as_json(include: includes)
     end
 
     def new
@@ -20,6 +20,10 @@ module Hangar
 
     def resource_attributes
       params.fetch(resource, {}).permit!
+    end
+
+    def includes
+      params.fetch(:include, [])
     end
   end
 end

--- a/spec/controllers/resources_controller_spec.rb
+++ b/spec/controllers/resources_controller_spec.rb
@@ -22,6 +22,19 @@ describe Hangar::ResourcesController do
       post :create, post: { title: 'Fun adventure' }, format: :json
       expect(json['title']).to eq('Fun adventure')
     end
+
+    it "accepts includes defining the association's columns" do
+      post :create, post: { title: 'Fun adventure' }, include: {"comments" => {"only" => "text"}},  format: :json
+      expect(json['title']).to eq('Fun adventure')
+      expect(json['comments'].count).to eq(5)
+      expect(json['comments'].first['text']).to eq("My comment")
+    end
+
+    it 'accepts includes defining associations' do
+      post :create, post: { title: 'Fun adventure' }, include: "comments",  format: :json
+      expect(json['title']).to eq('Fun adventure')
+      expect(json['comments'].count).to eq(5)
+    end
   end
 
   describe '#new' do

--- a/spec/dummy/app/models/comment.rb
+++ b/spec/dummy/app/models/comment.rb
@@ -1,0 +1,3 @@
+class Comment < ActiveRecord::Base
+  belongs_to :post
+end

--- a/spec/dummy/app/models/post.rb
+++ b/spec/dummy/app/models/post.rb
@@ -1,2 +1,3 @@
 class Post < ActiveRecord::Base
+  has_many :comments
 end

--- a/spec/dummy/db/migrate/20141114163953_create_comments.rb
+++ b/spec/dummy/db/migrate/20141114163953_create_comments.rb
@@ -1,0 +1,8 @@
+class CreateComments < ActiveRecord::Migration
+  def change
+    create_table :comments do |t|
+      t.string :text
+      t.belongs_to :post
+    end
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140610155904) do
+ActiveRecord::Schema.define(version: 20141114163953) do
+
+  create_table "comments", force: true do |t|
+    t.string  "text"
+    t.integer "post_id"
+  end
 
   create_table "posts", force: true do |t|
     t.text "title"

--- a/spec/dummy/spec/factories/comments.rb
+++ b/spec/dummy/spec/factories/comments.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :comment do
+    text 'My comment'
+  end
+end

--- a/spec/dummy/spec/factories/posts.rb
+++ b/spec/dummy/spec/factories/posts.rb
@@ -1,5 +1,6 @@
 FactoryGirl.define do
   factory :post do
     title 'Lorem ipsum'
+    comments { FactoryGirl.build_list :comment, 5 }
   end
 end


### PR DESCRIPTION
We needed a way to specify what associations are coming back via the REST service when creating a new object.

This update allows us to have a modify the as_json includes option to bring back the specified object graph for our client side tests.
