### PR TITLE
Allow for configuration of strategy being used by DatabaseCleaner

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@ You may have special tables in your test database that should not be cleared by 
 Hangar.do_not_delete = %w(very_important_things valuable_bitcoin_keys spatial_ref_sys) if defined?(Hangar)
 ```
 
+### Specifying DatabaseCleaner deletion strategy
+
+Not all ORMs support the deletion strategy, such as mongoid. You can override the clean strategy being used by the `DELETE /` request as follows:
+
+``` ruby
+# config/initializers/hangar.rb
+
+Hangar.clean_strategy = :truncation
+```
+
 ## Usage
 
 Hangar will create two factory routes for each factory registered with FactoryGirl. These routes mimic FactoryGirl's `create` and `attributes_for` methods, respectively:

--- a/app/controllers/hangar/records_controller.rb
+++ b/app/controllers/hangar/records_controller.rb
@@ -3,7 +3,7 @@ module Hangar
     respond_to :json
 
     def delete
-      DatabaseCleaner.clean_with :deletion, except: Hangar.do_not_delete
+      DatabaseCleaner.clean_with Hangar.clean_strategy, except: Hangar.do_not_delete
       render nothing: true, status: :no_content
     end
   end

--- a/lib/hangar.rb
+++ b/lib/hangar.rb
@@ -6,6 +6,8 @@ module Hangar
   BadEnvironmentError = Class.new(StandardError)
 
   mattr_writer :do_not_delete
+  mattr_accessor :clean_strategy
+  self.clean_strategy = :deletion
 
   def self.do_not_delete
     Array.wrap(@@do_not_delete)

--- a/spec/application/environment_spec.rb
+++ b/spec/application/environment_spec.rb
@@ -16,4 +16,8 @@ describe 'Application', :application do
       require File.expand_path("../../dummy/config/environment", __FILE__)
     }.to raise_error{Hangar::BadEnvironmentError}
   end
+
+  it 'defaults clean_strategy to deletion' do
+    expect(Hangar.clean_strategy).to eq :deletion
+  end
 end

--- a/spec/controllers/records_controller_spec.rb
+++ b/spec/controllers/records_controller_spec.rb
@@ -12,8 +12,26 @@ describe Hangar::RecordsController do
     end
 
     it 'does not delete important things' do
+      Hangar.clean_strategy = :deletion
       Hangar.do_not_delete = 'very_important_things'
       expect { delete :delete, format: :json }.not_to change(VeryImportantThing, :count)
+    end
+
+    it 'truncates the records' do
+      Hangar.clean_strategy = :truncation
+      expect { delete :delete, format: :json }.to change(Post, :count).by(-1)
+    end
+
+    it 'does not truncate important things' do
+      Hangar.clean_strategy = :truncation
+      Hangar.do_not_delete = 'very_important_things'
+      expect { delete :delete, format: :json }.not_to change(VeryImportantThing, :count)
+    end
+
+    it 'errors when given an invalid strategy' do
+      Hangar.clean_strategy = :invalid_strategy
+      expect { delete :delete, format: :json }.to raise_error(DatabaseCleaner::UnknownStrategySpecified)
+      Hangar.clean_strategy = :deletion
     end
   end
 end


### PR DESCRIPTION
ORM's such as Mongoid don't support the :deletion strategy in DatabaseCleaner.

I added the ability to configure the strategy being used by Hangar when invoking DatabaseCleaner's clean_with function.
