### PR TITLE
Rails 5 Parameters no longer inherit from Hash

### DIFF
--- a/app/controllers/hangar/resources_controller.rb
+++ b/app/controllers/hangar/resources_controller.rb
@@ -18,7 +18,7 @@ module Hangar
     end
 
     def resource_attributes
-      params.fetch(resource, {}).permit!
+      params.fetch(resource, {}).permit!.to_h
     end
 
     def traits


### PR DESCRIPTION
- need to call `.to_h` explicitly