### PR TITLE
Migrate from FactoryGirl to FactoryBot

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,6 @@ gemspec
 gem 'sqlite3'
 
 group :development, :test do
-  gem 'factory_girl_rails'
+  gem 'factory_bot_rails'
   gem 'rspec-rails'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    hangar (0.1.1)
+    hangar (0.1.2)
       database_cleaner
       rails (>= 4.1.0)
 
@@ -47,37 +47,31 @@ GEM
       tzinfo (~> 1.1)
     arel (8.0.0)
     builder (3.2.3)
-    coderay (1.1.2)
     concurrent-ruby (1.0.5)
     crass (1.0.2)
-    database_cleaner (1.6.1)
+    database_cleaner (1.7.0)
     diff-lcs (1.3)
     erubi (1.6.1)
-    factory_girl (4.8.1)
+    factory_bot (4.8.2)
       activesupport (>= 3.0.0)
-    factory_girl_rails (4.8.0)
-      factory_girl (~> 4.8.0)
+    factory_bot_rails (4.8.2)
+      factory_bot (~> 4.8.2)
       railties (>= 3.0.0)
-    globalid (0.4.0)
+    globalid (0.4.1)
       activesupport (>= 4.2.0)
     i18n (0.8.6)
     loofah (2.1.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.6.6)
-      mime-types (>= 1.16, < 4)
+    mail (2.7.0)
+      mini_mime (>= 0.1.1)
     method_source (0.9.0)
-    mime-types (3.1)
-      mime-types-data (~> 3.2015)
-    mime-types-data (3.2016.0521)
+    mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     minitest (5.10.3)
-    nio4r (2.1.0)
+    nio4r (2.3.1)
     nokogiri (1.8.1)
       mini_portile2 (~> 2.3.0)
-    pry (0.11.1)
-      coderay (~> 1.1.0)
-      method_source (~> 0.9.0)
     rack (2.0.3)
     rack-test (0.7.0)
       rack (>= 1.0, < 3)
@@ -140,18 +134,17 @@ GEM
       thread_safe (~> 0.1)
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.2)
+    websocket-extensions (0.1.3)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  factory_girl_rails
+  factory_bot_rails
   hangar!
-  pry
   rspec
   rspec-rails
   sqlite3
 
 BUNDLED WITH
-   1.12.5
+   1.16.1

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hangar
 
-Hangar is a Rails Engine that exposes your [FactoryGirl](https://github.com/thoughtbot/factory_girl) factories with a REST API available in the test environment only
+Hangar is a Rails Engine that exposes your [FactoryBot](https://github.com/thoughtbot/factory_girl) factories with a REST API available in the test environment only
 
 ## Install
 
@@ -12,7 +12,7 @@ gem 'hangar', group: :test
 
 ## Requirements
 
-Your application must use FactoryGirl to manage its factories. Follow [FactoryGirl's documentation](https://github.com/thoughtbot/factory_girl/blob/master/GETTING_STARTED.md) to add factories to your application.
+Your application must use FactoryBot to manage its factories. Follow [FactoryBot's documentation](https://github.com/thoughtbot/factory_girl/blob/master/GETTING_STARTED.md) to add factories to your application.
 
 ## Configuration
 
@@ -38,7 +38,7 @@ Hangar.clean_strategy = :truncation
 
 ## Usage
 
-Hangar will create two factory routes for each factory registered with FactoryGirl. These routes mimic FactoryGirl's `create` and `attributes_for` methods, respectively:
+Hangar will create two factory routes for each factory registered with FactoryBot. These routes mimic FactoryBot's `create` and `attributes_for` methods, respectively:
 
 ```
 POST /posts
@@ -97,7 +97,7 @@ You must include the following headers with your requests:
 
 ```
 Accept: application/json; charset=utf-8
-Content-Type: application/json    
+Content-Type: application/json
 Factory: hangar
 ```
 

--- a/app/controllers/hangar/resources_controller.rb
+++ b/app/controllers/hangar/resources_controller.rb
@@ -2,12 +2,12 @@ module Hangar
   class ResourcesController < ActionController::Base
 
     def create
-      created = FactoryGirl.create resource, *traits, resource_attributes
+      created = FactoryBot.create resource, *traits, resource_attributes
       render json: created.as_json(include: includes.as_json)
     end
 
     def new
-      attributes = FactoryGirl.attributes_for resource, *traits, resource_attributes
+      attributes = FactoryBot.attributes_for resource, *traits, resource_attributes
       render json: attributes
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   constraints Hangar::RouteConstraint.new do
-    FactoryGirl.factories.map(&:name).map(&:to_s).map(&:pluralize).map(&:to_sym).each do |factory|
+    FactoryBot.factories.map(&:name).map(&:to_s).map(&:pluralize).map(&:to_sym).each do |factory|
       resources factory, only: [:new, :create], controller: 'hangar/resources'
     end
     delete '/', to: 'hangar/records#delete'

--- a/spec/controllers/records_controller_spec.rb
+++ b/spec/controllers/records_controller_spec.rb
@@ -3,8 +3,8 @@ require 'spec_helper'
 describe Hangar::RecordsController do
   describe '#delete' do
     before do
-      FactoryGirl.create :post
-      FactoryGirl.create :very_important_thing
+      FactoryBot.create :post
+      FactoryBot.create :very_important_thing
     end
 
     it 'deletes all records' do

--- a/spec/controllers/resources_controller_spec.rb
+++ b/spec/controllers/resources_controller_spec.rb
@@ -15,7 +15,7 @@ describe Hangar::ResourcesController do
 
     it 'returns newly-created resource' do
       post :create, format: :json
-      expect(json.except('id')).to eq(FactoryGirl.create(:post).attributes.except('id'))
+      expect(json.except('id')).to eq(FactoryBot.create(:post).attributes.except('id'))
     end
 
     it 'accepts attributes' do
@@ -59,7 +59,7 @@ describe Hangar::ResourcesController do
       end
 
       it 'returns attributes' do
-        expect(response.body).to eq(FactoryGirl.attributes_for(:post).to_json)
+        expect(response.body).to eq(FactoryBot.attributes_for(:post).to_json)
       end
     end
 

--- a/spec/dummy/spec/factories/comments.rb
+++ b/spec/dummy/spec/factories/comments.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :comment do
     text 'My comment'
   end

--- a/spec/dummy/spec/factories/posts.rb
+++ b/spec/dummy/spec/factories/posts.rb
@@ -1,7 +1,7 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :post do
     title 'Lorem ipsum'
-    comments { FactoryGirl.build_list :comment, 5 }
+    comments { FactoryBot.build_list :comment, 5 }
 
     trait :trait do
       title 'Title changed by trait'

--- a/spec/dummy/spec/factories/very_important_things.rb
+++ b/spec/dummy/spec/factories/very_important_things.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :very_important_thing do
     name 'Love'
   end


### PR DESCRIPTION
Addresses the recent gem update from FactoryGirl to FactoryBot. [Learn more here](https://robots.thoughtbot.com/factory_bot#why)