### PR TITLE
Fix wrong factory name bug with namespaced routes

### DIFF
--- a/app/controllers/hangar/resources_controller.rb
+++ b/app/controllers/hangar/resources_controller.rb
@@ -14,7 +14,8 @@ module Hangar
     private
 
     def resource
-      request.path.split('/')[1].singularize.to_sym
+      index = Hangar.route_namespace[:path].present? ? 2 : 1
+      request.path.split('/')[index].singularize.to_sym
     end
 
     def resource_attributes

--- a/spec/controllers/records_controller_spec.rb
+++ b/spec/controllers/records_controller_spec.rb
@@ -37,5 +37,23 @@ describe Hangar::RecordsController do
       expect { delete :delete, format: :json }.to raise_error(DatabaseCleaner::UnknownStrategySpecified)
       Hangar.clean_strategy = clean_strategy
     end
+
+    context 'when route has a namespace' do
+      before do
+        Hangar.route_namespace = :factory
+        Rails.application.reload_routes!
+        request.path = '/factories'
+      end
+
+      after do
+        Hangar.route_namespace = nil
+        Rails.application.reload_routes!
+        request.path = '/'
+      end
+
+      it 'deletes the record' do
+        expect { delete :delete, format: :json }.to change(Post, :count).by(-1)
+      end
+    end
   end
 end

--- a/spec/controllers/resources_controller_spec.rb
+++ b/spec/controllers/resources_controller_spec.rb
@@ -40,6 +40,23 @@ describe Hangar::ResourcesController do
       post :create, params: { traits: ['trait'] }, format: :json
       expect(json['title']).to eq('Title changed by trait')
     end
+
+    context 'when route has a namespace' do
+      before do
+        Hangar.route_namespace = :factory
+        Rails.application.reload_routes!
+        request.path = '/factories/posts'
+      end
+
+      after do
+        Hangar.route_namespace = nil
+        Rails.application.reload_routes!
+      end
+
+      it 'creates resources' do
+        expect { post :create, format: :json }.to change(Post, :count).by(1)
+      end
+    end
   end
 
   describe '#new' do
@@ -82,6 +99,32 @@ describe Hangar::ResourcesController do
 
       it 'accepts traits' do
         expect(json['title']).to eq('Title changed by trait')
+      end
+    end
+
+    context 'when route has a namespace' do
+      before do
+        Hangar.route_namespace = :factory
+        Rails.application.reload_routes!
+        request.path = '/factories/posts'
+      end
+
+      after do
+        Hangar.route_namespace = nil
+        Rails.application.reload_routes!
+        request.path = '/'
+      end
+
+      before do
+        get :new, format: :json
+      end
+
+      it 'provides resource attributes' do
+        expect(response.status).to eq(200)
+      end
+
+      it 'returns attributes' do
+        expect(response.body).to eq(FactoryBot.attributes_for(:post).to_json)
       end
     end
   end


### PR DESCRIPTION
If you try to set namespace to something e.g. `factories`, then you won't be able to create any resource.
```
request.path.split('/')[1].singularize.to_sym
```
will use Factory name of `factories` in my example, which is not correct.
This PR fixes this issue.

Cheers!