### PR TITLE
refactor: unnecessary multiple #map chaining when declaring resource routes from factories

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   constraints Hangar::RouteConstraint.new do
     scope Hangar.route_namespace do
-      FactoryBot.factories.map(&:name).map(&:to_s).map(&:pluralize).map(&:to_sym).each do |factory|
+      FactoryBot.factories.map { |factory| factory.name.to_s.pluralize.to_sym }.each do |factory|
         resources factory, only: [:new, :create], controller: 'resources'
       end
       delete '/', to: 'records#delete'


### PR DESCRIPTION
Just a simply refactor and a bit of performance boost :smile: 