### PR TITLE
Request with include option, not parsing correctly

### DIFF
--- a/app/controllers/hangar/resources_controller.rb
+++ b/app/controllers/hangar/resources_controller.rb
@@ -5,7 +5,7 @@ module Hangar
 
     def create
       created = FactoryBot.create resource, *traits, resource_attributes
-      render json: created.as_json(include: includes.as_json)
+      render json: created.as_json(include: includes)
     end
 
     def new
@@ -29,7 +29,19 @@ module Hangar
     end
 
     def includes
-      @includes ||= params[:include].blank? ? [] : params.require(:include)
+      @includes ||= begin
+        _includes = params.fetch(:include, {}).as_json
+
+        unless _includes.is_a?(Hash)
+          array_of_assocation_and_options_pairs = Array(_includes).flat_map do |n|
+            n.is_a?(Hash) ? n.to_a : [[n, {}]]
+          end
+
+          _includes = Hash[array_of_assocation_and_options_pairs]
+        end
+
+        _includes.deep_symbolize_keys
+      end
     end
 
     def error_render_method(exception)

--- a/spec/controllers/resources_controller_spec.rb
+++ b/spec/controllers/resources_controller_spec.rb
@@ -29,7 +29,7 @@ describe Hangar::ResourcesController do
       expect(json['comments'].count).to eq(5)
       # this can be a custom matcher as well
       expect(json['comments']).to all(
-        satisfy("have only key 'text'") { |comment| !(comment.keys - ['text']).empty? }
+        satisfy("have only key 'text'") { |comment| (comment.keys - ['text']).empty? }
       )
     end
 

--- a/spec/controllers/resources_controller_spec.rb
+++ b/spec/controllers/resources_controller_spec.rb
@@ -27,7 +27,10 @@ describe Hangar::ResourcesController do
       post :create, params: { post: { title: 'Fun adventure' }, include: { comments: { only: :text } } },  format: :json
       expect(json['title']).to eq('Fun adventure')
       expect(json['comments'].count).to eq(5)
-      expect(json['comments'].first['text']).to eq("My comment")
+      # this can be a custom matcher as well
+      expect(json['comments']).to all(
+        satisfy("have only key 'text'") { |comment| !(comment.keys - ['text']).empty? }
+      )
     end
 
     it 'accepts includes defining associations' do


### PR DESCRIPTION
This is just a simple commit which makes the [resources controller spec](https://github.com/faradayio/hangar/blob/master/spec/controllers/resources_controller_spec.rb#L26-L31) for including the association along with its fields more precise. If you think that this is a bug, I am willing to resolve it with expanding this PR.