### PR TITLE
Show more detailed error messages

### DIFF
--- a/app/controllers/hangar/resources_controller.rb
+++ b/app/controllers/hangar/resources_controller.rb
@@ -1,8 +1,5 @@
 module Hangar
   class ResourcesController < ActionController::Base
-
-    rescue_from StandardError, :with => :error_render_method
-
     def create
       created = FactoryBot.create resource, *traits, resource_attributes
       render json: created.as_json(include: includes)
@@ -42,15 +39,6 @@ module Hangar
 
         _includes.deep_symbolize_keys
       end
-    end
-
-    def error_render_method(exception)
-      status_code = ActionDispatch::ExceptionWrapper.new(env, exception).status_code
-      respond_to do |type|
-        type.json { render :json => {error: exception.message}.to_json, :status => status_code}
-        type.all { throw exception }
-      end
-      true
     end
   end
 end


### PR DESCRIPTION
When sending requests from a front end app to the api, if a required attribute for the model you’re attempting to create with hangar is missing, the error message in the rails logs displays:

```
<NameError: undefined local variable or method 'env' for #<Hangar::ResourcesController:0x00007f7ee8b039c0>>
```

Removing this StandardError rescue surfaces the true error to us in the rails logs. Now it will report back which required fields are missing.

Another example: If I am trying to create a hospital model using hangar and the test environment migrations haven’t been run, the rails logs will show:

```
#<ActiveRecord::StatementInvalid: PG::UndefinedTable: ERROR:  relation "hospitals" does not exist
LINE 8:                WHERE a.attrelid = '"hospitals"'::regclass
                                          ^
:               SELECT a.attname, format_type(a.atttypid, a.atttypmod),
                     pg_get_expr(d.adbin, d.adrelid), a.attnotnull, a.atttypid, a.atttypmod,
                     c.collname, col_description(a.attrelid, a.attnum) AS comment
                FROM pg_attribute a
                LEFT JOIN pg_attrdef d ON a.attrelid = d.adrelid AND a.attnum = d.adnum
                LEFT JOIN pg_type t ON a.atttypid = t.oid
                LEFT JOIN pg_collation c ON a.attcollation = c.oid AND a.attcollation <> t.typcollation
               WHERE a.attrelid = '"hospitals"'::regclass
                 AND a.attnum > 0 AND NOT a.attisdropped
               ORDER BY a.attnum
>
```

In lieu of what had been showing:

```
<NameError: undefined local variable or method 'env' for #<Hangar::ResourcesController:0x00007f7ee8b039c0>>
```

Which is less indicative of what the problem is.